### PR TITLE
refactor(ui): 검색 UI 통일 및 레이아웃 개선

### DIFF
--- a/public/styles/layout.css
+++ b/public/styles/layout.css
@@ -39,9 +39,9 @@ nav {
   --pagefind-ui-font: Palatino, "Palatino Linotype", serif;
   --pagefind-ui-primary: #000;
   --pagefind-ui-text: #000;
-  --pagefind-ui-border: #eee;
+  --pagefind-ui-border: transparent;
   --pagefind-ui-tag: #eee;
-  --pagefind-ui-border-width: 1px;
+  --pagefind-ui-border-width: 0;
   --pagefind-ui-border-radius: 0;
   --pagefind-ui-image-border-radius: 0;
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,7 +14,7 @@ export const PATHS = {
 } as const;
 
 export const NAV_LINKS = [
-  { href: "/", label: "Home" },
+  { href: "/", label: "Root" },
   { href: "/publications", label: "Publications" },
   { href: "/thoughts", label: "Thoughts" },
   { href: "/notebooks", label: "Notebooks" },

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -5,11 +5,12 @@ import { SITE } from "@/config";
 interface Props {
 	title: string;
 	description?: string;
+	showSearch?: boolean;
 }
 
-const { title, description = `${SITE.name} - ${SITE.author}'s Web Logs` } = Astro.props;
-const siteTitle = title === "Home" ? SITE.name : `${title} | ${SITE.name}`;
-const ogTitle = title === "Home" ? SITE.name : title;
+const { title, description = `${SITE.name} - ${SITE.author}'s Web Logs`, showSearch = false } = Astro.props;
+const siteTitle = title === "Root" ? SITE.name : `${title} | ${SITE.name}`;
+const ogTitle = title === "Root" ? SITE.name : title;
 const ogImageUrl = `${SITE.url}/api/og-image?title=${encodeURIComponent(ogTitle)}`;
 const canonicalUrl = Astro.url.href.replace(Astro.url.origin, SITE.url);
 ---
@@ -29,33 +30,35 @@ const canonicalUrl = Astro.url.href.replace(Astro.url.origin, SITE.url);
 		<meta property="og:type" content="article" />
 		<meta name="twitter:card" content="summary_large_image" />
 		<link rel="stylesheet" href="/styles/layout.css" />
-		<link rel="stylesheet" href="/pagefind/pagefind-ui.css" />
+		{showSearch && <link rel="stylesheet" href="/pagefind/pagefind-ui.css" />}
 		<link rel="alternate" type="application/rss+xml" title={`${SITE.name} RSS`} href="/feed.xml" />
 	</head>
 	<body>
 		<header>
 			<Nav />
-			<div id="search"></div>
 		</header>
-		<script>
-			window.addEventListener("DOMContentLoaded", () => {
-				// @ts-ignore
-				new PagefindUI({
-					element: "#search",
-					showSubResults: true,
-					translations: {
-						placeholder: "Search",
-						clear_search: "Clear",
-						load_more: "Load more results",
-						zero_results: "No results for [SEARCH_TERM]",
-						many_results: "[COUNT] results for [SEARCH_TERM]",
-						one_result: "[COUNT] result for [SEARCH_TERM]",
-						searching: "Searching for [SEARCH_TERM]...",
-					},
+		{showSearch && (
+			<div id="search"></div>
+			<script>
+				window.addEventListener("DOMContentLoaded", () => {
+					// @ts-ignore
+					new PagefindUI({
+						element: "#search",
+						showSubResults: true,
+						translations: {
+							placeholder: "Search",
+							clear_search: "Clear",
+							load_more: "Load more results",
+							zero_results: "No results for [SEARCH_TERM]",
+							many_results: "[COUNT] results for [SEARCH_TERM]",
+							one_result: "[COUNT] result for [SEARCH_TERM]",
+							searching: "Searching for [SEARCH_TERM]...",
+						},
+					});
 				});
-			});
-		</script>
-		<script src="/pagefind/pagefind-ui.js" is:inline></script>
+			</script>
+			<script src="/pagefind/pagefind-ui.js" is:inline></script>
+		)}
 		<main>
 			<slot />
 		</main>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -2,8 +2,8 @@
 import Layout from "@/layouts/Layout.astro";
 ---
 
-<Layout title="404" description="페이지를 찾을 수 없습니다">
+<Layout title="404" description="Page not found">
 	<h1>404</h1>
-	<p>이 글은 아카이브되었거나 존재하지 않습니다.</p>
-	<p><a href="/">홈으로 돌아가기</a></p>
+	<p>This page has been archived or does not exist.</p>
+	<p><a href="/">Back to Root</a></p>
 </Layout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -3,7 +3,7 @@ import { SITE } from "@/config";
 import Layout from "@/layouts/Layout.astro";
 ---
 
-<Layout title="Home">
+<Layout title="Root">
 	<h1>{SITE.name}</h1>
 	<p>TODO: Landing page</p>
 </Layout>

--- a/src/pages/notebooks/index.astro
+++ b/src/pages/notebooks/index.astro
@@ -7,7 +7,7 @@ const publishedDates = loadPublishedDates();
 const posts = sortByDate(getPostsByType("notebook"), publishedDates);
 ---
 
-<Layout title="Notebooks">
+<Layout title="Notebooks" showSearch>
 	<h1>Notebooks</h1>
 
 	{posts.length === 0 ? (

--- a/src/pages/publications/index.astro
+++ b/src/pages/publications/index.astro
@@ -7,7 +7,7 @@ const publishedDates = loadPublishedDates();
 const posts = sortByDate(getPostsByType("publication"), publishedDates);
 ---
 
-<Layout title="Publications">
+<Layout title="Publications" showSearch>
 	<h1>Publications</h1>
 
 	{posts.length === 0 ? (

--- a/src/pages/thoughts/index.astro
+++ b/src/pages/thoughts/index.astro
@@ -7,7 +7,7 @@ const publishedDates = loadPublishedDates();
 const posts = sortByDate(getPostsByType("thought"), publishedDates);
 ---
 
-<Layout title="Thoughts">
+<Layout title="Thoughts" showSearch>
 	<h1>Thoughts</h1>
 
 	{posts.length === 0 ? (


### PR DESCRIPTION
## Summary
- Pagefind 검색 UI 디자인 언어를 앱 전체와 통일 (font, border, radius, weight)
- 검색 UI를 리스트 페이지에서만 조건부 렌더링 (`showSearch` prop)
- Pagefind border 완전 제거 (transparent, width 0)
- "Home" → "Root" 네이밍 통일
- 404 페이지 텍스트 영문화

## Test plan
- [ ] `pnpm run build` 성공 확인
- [ ] 리스트 페이지(Publications, Thoughts, Notebooks)에서 검색 UI 표시 확인
- [ ] 비리스트 페이지(Root, 404)에서 검색 UI 미표시 확인
- [ ] 검색 입력 필드 스타일: Palatino serif, 직각, border 없음, normal weight
- [ ] Nav "Root" 라벨, 404 영문 텍스트 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)