### PR TITLE
fix: 구글 색인 개선을 위한 SEO 메타 태그 보강

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -3,7 +3,11 @@ import { defineConfig } from "astro/config";
 
 export default defineConfig({
 	site: "https://non.salon",
-	integrations: [sitemap()],
+	integrations: [
+		sitemap({
+			filter: (page) => !page.includes("/404"),
+		}),
+	],
 	output: "static",
 	build: {
 		format: "file",

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -9,6 +9,7 @@ interface Props {
 	ogType?: "website" | "article";
 	ogImage?: string;
 	publishedDate?: string;
+	noindex?: boolean;
 }
 
 const {
@@ -18,6 +19,7 @@ const {
 	ogType = "website",
 	ogImage,
 	publishedDate,
+	noindex = false,
 } = Astro.props;
 const siteTitle = title === "Root" ? SITE.name : `${title} | ${SITE.name}`;
 const ogTitle = title === "Root" ? SITE.name : title;
@@ -25,14 +27,18 @@ const ogImageUrl = `${SITE.url}/og/${ogImage || "default.png"}`;
 const canonicalUrl = Astro.url.href.replace(Astro.url.origin, SITE.url);
 
 // JSON-LD 구조화 데이터: 상세 페이지는 Article, 그 외는 WebSite
+const robotsMeta = noindex ? "noindex, nofollow" : "index, follow";
+
 const jsonLd =
 	ogType === "article"
 		? {
 				"@context": "https://schema.org",
 				"@type": "Article",
 				headline: ogTitle,
+				description,
 				datePublished: publishedDate,
 				author: { "@type": "Person", name: SITE.author },
+				publisher: { "@type": "Person", name: SITE.author },
 				image: ogImageUrl,
 				url: canonicalUrl,
 			}
@@ -51,6 +57,9 @@ const jsonLd =
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 		<meta name="description" content={description} />
+		<meta name="robots" content={robotsMeta} />
+		<meta name="googlebot" content={robotsMeta} />
+		<meta name="author" content={SITE.author} />
 		<title>{siteTitle}</title>
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 		<link rel="canonical" href={canonicalUrl} />
@@ -59,6 +68,8 @@ const jsonLd =
 		<meta property="og:image" content={ogImageUrl} />
 		<meta property="og:url" content={canonicalUrl} />
 		<meta property="og:type" content={ogType} />
+		<meta property="og:site_name" content={SITE.name} />
+		<meta property="og:locale" content="ko_KR" />
 		<meta name="twitter:card" content="summary_large_image" />
 		<script type="application/ld+json" set:html={JSON.stringify(jsonLd)} />
 		<link rel="stylesheet" href="/styles/layout.css" />

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -2,7 +2,7 @@
 import Layout from "@/layouts/Layout.astro";
 ---
 
-<Layout title="404" description="Page not found">
+<Layout title="404" description="Page not found" noindex>
 	<h1>404</h1>
 	<p>This page has been archived or does not exist.</p>
 	<p><a href="/">Back to Root</a></p>


### PR DESCRIPTION
- Layout.astro: robots, googlebot, author, og:site_name, og:locale 메타 태그 추가
- Layout.astro: noindex prop 추가 (기본값 false, 404 등 특정 페이지용)
- Layout.astro: JSON-LD Article 스키마에 description, publisher 필드 추가
- 404.astro: noindex 처리로 검색 엔진 인덱싱 방지
- astro.config.mjs: sitemap에서 404 페이지 제외

Closes #5