### PR TITLE
fix(seo): canonical URL 정규화

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,6 +1,7 @@
 ---
 import Nav from "@/components/Nav.astro";
 import { SITE } from "@/config";
+import { toCanonicalUrl } from "@/lib/seo";
 
 interface Props {
 	title: string;
@@ -9,6 +10,7 @@ interface Props {
 	ogType?: "website" | "article";
 	ogImage?: string;
 	publishedDate?: string;
+	modifiedDate?: string;
 	noindex?: boolean;
 }
 
@@ -19,12 +21,13 @@ const {
 	ogType = "website",
 	ogImage,
 	publishedDate,
+	modifiedDate,
 	noindex = false,
 } = Astro.props;
 const siteTitle = title === "Root" ? SITE.name : `${title} | ${SITE.name}`;
 const ogTitle = title === "Root" ? SITE.name : title;
 const ogImageUrl = `${SITE.url}/og/${ogImage || "default.png"}`;
-const canonicalUrl = Astro.url.href.replace(Astro.url.origin, SITE.url);
+const canonicalUrl = toCanonicalUrl(Astro.url);
 
 // JSON-LD 구조화 데이터: 상세 페이지는 Article, 그 외는 WebSite
 const robotsMeta = noindex ? "noindex, nofollow" : "index, follow";
@@ -37,6 +40,7 @@ const jsonLd =
 				headline: ogTitle,
 				description,
 				datePublished: publishedDate,
+				dateModified: modifiedDate,
 				author: { "@type": "Person", name: SITE.author },
 				publisher: { "@type": "Person", name: SITE.author },
 				image: ogImageUrl,

--- a/src/lib/seo.test.ts
+++ b/src/lib/seo.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import type { Post } from "@/types";
+import { getArticleModifiedDate, toCanonicalUrl } from "./seo";
+
+const post: Post = {
+	id: "post-id",
+	title: "Post title",
+	slug: "post-title",
+	type: "publication",
+	status: "Published",
+	description: "Post description",
+	tags: [],
+	lastUpdated: null,
+	lastEditedTime: "2026-03-21T10:30:00.000Z",
+	createdTime: "2026-03-19T10:30:00.000Z",
+	publishedDate: "2026-03-20",
+	blocks: [],
+};
+
+describe("toCanonicalUrl", () => {
+	it("uses extensionless URLs for Astro file build output", () => {
+		expect(toCanonicalUrl(new URL("https://example.com/publications.html"))).toBe(
+			"https://non.salon/publications",
+		);
+	});
+
+	it("normalizes detail pages and strips query and hash", () => {
+		expect(
+			toCanonicalUrl(new URL("https://example.com/publication/post-title.html?ref=feed#code")),
+		).toBe("https://non.salon/publication/post-title");
+	});
+
+	it("keeps the root canonical URL with a trailing slash", () => {
+		expect(toCanonicalUrl(new URL("https://example.com/index.html"))).toBe("https://non.salon/");
+	});
+});
+
+describe("getArticleModifiedDate", () => {
+	it("prefers explicit Last Updated metadata", () => {
+		expect(getArticleModifiedDate({ ...post, lastUpdated: "2026-03-22" })).toBe("2026-03-22");
+	});
+
+	it("falls back to the Notion last edited date", () => {
+		expect(getArticleModifiedDate(post)).toBe("2026-03-21");
+	});
+});

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -1,0 +1,19 @@
+import { SITE } from "@/config";
+import type { Post } from "@/types";
+
+export function toCanonicalUrl(url: URL): string {
+	const siteUrl = new URL(SITE.url);
+	let pathname = url.pathname;
+
+	if (pathname === "/index.html") {
+		pathname = "/";
+	} else if (pathname.endsWith(".html")) {
+		pathname = pathname.slice(0, -".html".length);
+	}
+
+	return new URL(pathname, siteUrl).href;
+}
+
+export function getArticleModifiedDate(post: Post): string {
+	return (post.lastUpdated || post.lastEditedTime).split("T")[0];
+}

--- a/src/pages/[type]/[slug].astro
+++ b/src/pages/[type]/[slug].astro
@@ -4,6 +4,7 @@ import Layout from "@/layouts/Layout.astro";
 import { blocksToHtml } from "@/lib/block-to-html";
 import { formatDate } from "@/lib/format";
 import { getPostsByType, getPublishedDate, loadPublishedDates } from "@/lib/posts";
+import { getArticleModifiedDate } from "@/lib/seo";
 import type { Post } from "@/types";
 
 export function getStaticPaths() {
@@ -25,6 +26,7 @@ export function getStaticPaths() {
 const { post } = Astro.props as { post: Post };
 const publishedDates = loadPublishedDates();
 const publishedDate = getPublishedDate(post, publishedDates);
+const modifiedDate = getArticleModifiedDate(post);
 const content = blocksToHtml(post.blocks);
 ---
 
@@ -34,6 +36,7 @@ const content = blocksToHtml(post.blocks);
 	ogType="article"
 	ogImage={`${post.type}-${post.slug}.png`}
 	publishedDate={publishedDate}
+	modifiedDate={modifiedDate}
 >
 	<article>
 		<header>


### PR DESCRIPTION
## Summary
- canonical URL을 Cloudflare Pages가 실제로 서빙하고 sitemap이 제출하는 extensionless URL과 일치하도록 정규화
- `og:url`과 Article JSON-LD `url`도 동일한 canonical 값을 사용하도록 정리
- Notion `Last Updated`/`lastEditedTime` 기반 `dateModified`를 Article 구조화 데이터에 추가
- canonical/dateModified 동작을 `src/lib/seo.test.ts`로 고정

## Why
라이브 페이지는 `/publications`처럼 extensionless URL을 200으로 서빙하고 `/publications.html`은 redirect하지만, 기존 HTML head는 `.html` URL을 canonical로 선언하고 있었습니다. 내부 링크와 sitemap은 extensionless URL을 가리키고 있어 검색엔진 색인 신호가 갈라질 수 있었습니다.

## Verification
- `pnpm test:run` → 42 tests passed
- `pnpm lint` → exit 0, existing `src/lib/image-handler.ts` unused `error` warning remains
- `pnpm build:astro` → build succeeded, 8 pages built
- Built HTML 확인: canonical/`og:url`/JSON-LD `url`이 extensionless URL로 출력됨