### PR TITLE
feat(home): 최신 글 노출 및 통합 아카이브 추가

### DIFF
--- a/docs/plans/2026-07-23-latest-posts-archive-design.md
+++ b/docs/plans/2026-07-23-latest-posts-archive-design.md
@@ -1,0 +1,52 @@
+# 최신 글 홈 노출 및 통합 아카이브 설계
+
+## 목표
+
+루트 페이지(`/`)에서 카테고리와 관계없이 최신 글 5개를 보여주고, 전체 혼합 목록은 `/archive`에서 제공한다.
+
+## 현재 구조
+
+- `data/posts.json`을 `src/lib/posts.ts`의 `loadPosts()`로 읽는다.
+- `getPostsByType()`는 카테고리별 목록 페이지에서 사용한다.
+- `sortByDate()`는 `publishedDate` → `published-dates.json` → `lastEditedTime` 순서로 날짜를 결정하고 최신순 정렬한다.
+- 현재 루트 페이지(`src/pages/index.astro`)는 사이트 제목과 설명만 렌더링한다.
+- 현재 카테고리 목록 페이지는 각 타입별 전체 목록을 이미 제공한다.
+
+## 결정 사항
+
+### 홈
+
+`loadPosts()`로 모든 글을 불러오고 기존 `sortByDate()`로 통합 정렬한 뒤 상위 5개만 노출한다. 각 항목에는 카테고리, 날짜, 제목을 표시하고 기존 단수형 상세 경로(`/{type}/{slug}`)로 연결한다.
+
+홈에는 전체 목록으로 이동하는 `/archive` 링크를 둔다. 상단 전역 내비게이션에는 당장 추가하지 않는다.
+
+### 아카이브
+
+`src/pages/archive/index.astro`를 추가해 모든 카테고리의 글을 최신순으로 보여준다. 홈과 동일한 날짜 계산 및 상세 경로 규칙을 사용한다.
+
+이번 변경에서는 페이지네이션을 추가하지 않는다. 글 수가 실제로 많아지면 `/archive/[page]` 또는 `/archive/[...page]` 기반의 정적 페이지네이션을 별도 변경으로 도입한다.
+
+## 데이터 흐름
+
+```text
+Notion DB
+  -> data/posts.json
+  -> loadPosts()
+  -> sortByDate(allPosts, publishedDates)
+  -> slice(0, 5)       -> /
+  -> full list          -> /archive
+```
+
+## 구현 범위
+
+- 수정: `src/pages/index.astro`
+- 추가: `src/pages/archive/index.astro`
+- 필요 시 공통 스타일은 각 페이지의 기존 스타일 패턴을 따른다.
+- 게시물 타입, 데이터 스키마, Notion fetcher, 기존 카테고리 페이지는 변경하지 않는다.
+
+## 검증
+
+- `pnpm test:run`
+- `pnpm lint`
+- `pnpm build:astro` (생성된 `data/posts.json`이 없는 환경에서는 기존 프로젝트 동작에 따라 별도 확인)
+

--- a/docs/plans/2026-07-23-latest-posts-archive.md
+++ b/docs/plans/2026-07-23-latest-posts-archive.md
@@ -1,0 +1,100 @@
+# 최신 글 홈 노출 및 통합 아카이브 Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** 루트 페이지에 모든 카테고리의 최신 글 5개를 노출하고, 전체 혼합 목록을 `/archive`에서 제공한다.
+
+**Architecture:** 게시물 데이터는 기존 `loadPosts()`로 한 번에 읽고, `posts.ts`에 추가하는 작은 `getLatestPosts()` 유틸로 공통 최신순 정렬과 선택 개수를 관리한다. 홈과 아카이브의 표시 마크업과 스타일은 각 Astro 페이지에 둔다. 이번 범위에서는 페이지네이션과 전역 내비게이션 변경을 하지 않는다.
+
+**Tech Stack:** Astro 5, TypeScript, Vitest, Biome
+
+---
+
+### Task 1: 최신 게시물 선택 로직 테스트 작성
+
+**Files:**
+- Create: `src/lib/posts.test.ts`
+- Modify: none
+
+**Step 1: Write the failing test**
+
+혼합된 `publication`, `thought`, `notebook` 게시물을 준비하고 `getLatestPosts()`가 카테고리를 필터링하지 않은 채 최신순으로 정렬하며 limit을 적용하는지 검증한다.
+
+**Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run src/lib/posts.test.ts`
+
+Expected: FAIL because `getLatestPosts` is not exported yet.
+
+### Task 2: 공통 최신 게시물 유틸 구현
+
+**Files:**
+- Modify: `src/lib/posts.ts`
+- Test: `src/lib/posts.test.ts`
+
+**Step 1: Write minimal implementation**
+
+`sortByDate()`를 재사용하는 `getLatestPosts(posts, publishedDates, limit?)`를 추가한다. limit이 없으면 전체 정렬 목록을 반환하고, limit이 있으면 정렬 결과의 앞부분만 반환한다. 입력 배열은 변경하지 않는다.
+
+**Step 2: Run test to verify it passes**
+
+Run: `pnpm vitest run src/lib/posts.test.ts`
+
+Expected: PASS.
+
+### Task 3: 홈 및 아카이브 페이지 구현
+
+**Files:**
+- Modify: `src/pages/index.astro`
+- Create: `src/pages/archive/index.astro`
+
+**Step 1: Implement home page**
+
+기존 제목과 설명 아래에 최신 게시물 5개를 표시한다. 각 항목에 타입 라벨, 날짜, 제목을 표시하고 `/${post.type}/${post.slug}`로 연결한다. 목록 아래에 `/archive` 링크를 추가한다. 게시물이 없으면 기존 목록 페이지와 동일하게 `No posts yet.`를 표시한다.
+
+**Step 2: Implement archive page**
+
+모든 타입의 게시물을 `getLatestPosts()`로 정렬해 표시한다. 홈과 같은 날짜/타입/상세 URL 규칙을 사용한다. 빈 목록 상태를 처리한다.
+
+**Step 3: Match existing visual conventions**
+
+기존 카테고리 목록 페이지의 타이포그래피, 간격, border, muted date 색상을 재사용하고, 전역 스타일을 불필요하게 변경하지 않는다.
+
+### Task 4: 전체 검증
+
+**Files:**
+- Verify: `src/pages/index.astro`
+- Verify: `src/pages/archive/index.astro`
+- Verify: `src/lib/posts.ts`
+- Verify: `src/lib/posts.test.ts`
+
+**Step 1: Run focused tests**
+
+Run: `pnpm vitest run src/lib/posts.test.ts`
+
+Expected: PASS.
+
+**Step 2: Run full test suite**
+
+Run: `pnpm test:run`
+
+Expected: all tests PASS.
+
+**Step 3: Run lint**
+
+Run: `pnpm lint`
+
+Expected: Biome reports no errors.
+
+**Step 4: Run Astro build**
+
+Run: `pnpm build:astro`
+
+Expected: Astro generates `/` and `/archive/` successfully. If `data/posts.json` is absent, record the repository's existing empty-data build behavior rather than changing the data pipeline.
+
+**Step 5: Inspect the final diff**
+
+Run: `git diff --check` and `git status --short`
+
+Expected: no whitespace errors; only intended feature files are modified in addition to the already committed plan files.
+

--- a/src/lib/posts.test.ts
+++ b/src/lib/posts.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import type { Post } from "@/types";
+import { getLatestPosts } from "./posts";
+
+function makePost(overrides: Partial<Post>): Post {
+	return {
+		id: "post-id",
+		title: "Post title",
+		slug: "post-slug",
+		type: "thought",
+		status: "Published",
+		description: null,
+		tags: [],
+		lastUpdated: null,
+		lastEditedTime: "2026-01-01T00:00:00.000Z",
+		createdTime: "2026-01-01T00:00:00.000Z",
+		publishedDate: null,
+		blocks: [],
+		...overrides,
+	};
+}
+
+describe("getLatestPosts", () => {
+	it("sorts posts across content types and applies a limit", () => {
+		const posts = [
+			makePost({ id: "older", slug: "older", type: "notebook", publishedDate: "2026-01-01" }),
+			makePost({ id: "newest", slug: "newest", type: "thought", publishedDate: "2026-03-01" }),
+			makePost({
+				id: "middle",
+				slug: "middle",
+				type: "publication",
+				publishedDate: "2026-02-01",
+			}),
+		];
+
+		const latestPosts = getLatestPosts(posts, {}, 2);
+
+		expect(latestPosts.map((post) => `${post.type}:${post.slug}`)).toEqual([
+			"thought:newest",
+			"publication:middle",
+		]);
+	});
+});

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -42,6 +42,15 @@ export function sortByDate(
 	});
 }
 
+export function getLatestPosts(
+	posts: Post[],
+	publishedDates: Record<string, string>,
+	limit?: number,
+): Post[] {
+	const sortedPosts = sortByDate(posts, publishedDates);
+	return limit === undefined ? sortedPosts : sortedPosts.slice(0, limit);
+}
+
 export function getPublishedDate(post: Post, publishedDates: Record<string, string>): string {
 	return post.publishedDate || publishedDates[post.slug] || post.lastEditedTime.split("T")[0];
 }

--- a/src/pages/archive/index.astro
+++ b/src/pages/archive/index.astro
@@ -1,0 +1,82 @@
+---
+import Layout from "@/layouts/Layout.astro";
+import { formatDate } from "@/lib/format";
+import { getLatestPosts, getPublishedDate, loadPosts, loadPublishedDates } from "@/lib/posts";
+
+const publishedDates = loadPublishedDates();
+const posts = getLatestPosts(loadPosts(), publishedDates);
+const typeLabels = {
+	publication: "Publication",
+	thought: "Thought",
+	notebook: "Notebook",
+};
+---
+
+<Layout title="Archive" description="All posts" showSearch>
+	<h1>Archive</h1>
+
+	{posts.length === 0 ? (
+		<p>No posts yet.</p>
+	) : (
+		<div class="posts">
+			{posts.map((post) => {
+				const date = getPublishedDate(post, publishedDates);
+				return (
+					<article>
+						<div class="meta">
+							<span>{typeLabels[post.type]}</span>
+							<time datetime={date}>{formatDate(date)}</time>
+						</div>
+						<h2><a href={`/${post.type}/${post.slug}`}>{post.title}</a></h2>
+						{post.description && <p>{post.description}</p>}
+					</article>
+				);
+			})}
+		</div>
+	)}
+</Layout>
+
+<style>
+	h1 {
+		margin-bottom: 2rem;
+	}
+
+	.posts {
+		display: flex;
+		flex-direction: column;
+		gap: 2rem;
+	}
+
+	article {
+		padding-bottom: 2rem;
+		border-bottom: 1px solid var(--color-border);
+	}
+
+	article:last-child {
+		border-bottom: none;
+	}
+
+	.meta {
+		display: flex;
+		gap: 0.75rem;
+		color: var(--color-muted);
+		font-size: var(--font-size-sm);
+	}
+
+	article h2 {
+		margin: 0.5rem 0 0;
+	}
+
+	article h2 a {
+		text-decoration: none;
+	}
+
+	article h2 a:hover {
+		text-decoration: underline;
+	}
+
+	article p {
+		margin: 0.5rem 0 0;
+		color: var(--color-subtle);
+	}
+</style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,9 +1,108 @@
 ---
 import { SITE } from "@/config";
 import Layout from "@/layouts/Layout.astro";
+import { formatDate } from "@/lib/format";
+import { getLatestPosts, getPublishedDate, loadPosts, loadPublishedDates } from "@/lib/posts";
+
+const publishedDates = loadPublishedDates();
+const posts = getLatestPosts(loadPosts(), publishedDates, 5);
+const typeLabels = {
+	publication: "Publication",
+	thought: "Thought",
+	notebook: "Notebook",
+};
 ---
 
 <Layout title="Root">
 	<h1>{SITE.name}</h1>
 	<p>Archived Web Logs.</p>
+
+	<section class="latest">
+		<div class="section-heading">
+			<h2>Latest Posts</h2>
+			<a href="/archive">View all posts</a>
+		</div>
+
+		{posts.length === 0 ? (
+			<p>No posts yet.</p>
+		) : (
+			<div class="posts">
+				{posts.map((post) => {
+					const date = getPublishedDate(post, publishedDates);
+					return (
+						<article>
+							<div class="meta">
+								<span>{typeLabels[post.type]}</span>
+								<time datetime={date}>{formatDate(date)}</time>
+							</div>
+							<h3><a href={`/${post.type}/${post.slug}`}>{post.title}</a></h3>
+						</article>
+					);
+				})}
+			</div>
+		)}
+	</section>
 </Layout>
+
+<style>
+	h1 {
+		margin-bottom: 0.5rem;
+	}
+
+	.latest {
+		margin-top: 4rem;
+	}
+
+	.section-heading {
+		display: flex;
+		align-items: baseline;
+		justify-content: space-between;
+		gap: 1rem;
+		margin-bottom: 2rem;
+	}
+
+	.section-heading h2 {
+		margin: 0;
+	}
+
+	.section-heading a {
+		color: var(--color-muted);
+		font-size: var(--font-size-sm);
+	}
+
+	.posts {
+		display: flex;
+		flex-direction: column;
+		gap: 1.5rem;
+	}
+
+	article {
+		padding-bottom: 1.5rem;
+		border-bottom: 1px solid var(--color-border);
+	}
+
+	article:last-child {
+		border-bottom: none;
+	}
+
+	.meta {
+		display: flex;
+		gap: 0.75rem;
+		color: var(--color-muted);
+		font-size: var(--font-size-sm);
+	}
+
+	article h3 {
+		margin: 0.35rem 0 0;
+		font-size: 1.1rem;
+		font-weight: normal;
+	}
+
+	article h3 a {
+		text-decoration: none;
+	}
+
+	article h3 a:hover {
+		text-decoration: underline;
+	}
+</style>


### PR DESCRIPTION
## 변경 사항

- 루트 페이지에 카테고리와 관계없이 최신 글 5개를 표시
- 전체 혼합 목록을 `/archive`에서 최신순으로 표시
- 타입, 날짜, 상세 페이지 링크를 함께 표시
- 공통 최신 글 정렬 유틸 `getLatestPosts()`와 테스트 추가
- 설계 및 구현 계획 문서 추가

## 목적

홈에서는 최근 콘텐츠를 빠르게 확인하고, 전체 글은 별도 아카이브에서 탐색할 수 있도록 구성했습니다. 페이지네이션은 이번 범위에 포함하지 않았습니다.

## 검증

- `pnpm test:run` — 46개 테스트 통과
- `pnpm lint` — 기존 `src/lib/image-handler.ts:132` 경고 1건
- `pnpm build:astro` — 9개 페이지 생성 성공
